### PR TITLE
Add server_update_available trigger and condition, fix widget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# tv.plex — Homey App for Plex
+
+## What this is
+
+A [Homey](https://homey.app) SDK 3 app that integrates Plex Media Server into Athom smart home hubs. Provides Flow triggers (recently added, player start/pause/stop, server update available), conditions (server update is available), actions (rescan/refresh library), and a dashboard widget.
+
+## Commands
+
+```sh
+npm run lint       # ESLint (athom/homey-app config)
+npm run validate   # homey app validate --level publish (runs compose then validates)
+npm run publish    # homey app publish
+```
+
+### Homey CLI commands
+
+```sh
+homey app install    # Install app on connected Homey device
+homey app validate   # Validate (runs compose then validates)
+homey app compose    # One-time migration to compose (already enabled)
+homey app run        # Run in dev mode (Docker required on Homey 2023+)
+homey app build      # Build for publishing
+```
+
+CI runs `validate` at `verified` level on push/PR to master via `.github/workflows/homey-app-validate.yml`.
+
+**Note:** `npm run validate` / `homey app validate` runs the compose plugin (`homeycompose`) which regenerates `app.json` from the compose sources. The compose plugin does **not** auto-discover widgets — they must be declared in `.homeycompose/app.json` under a `widgets` property.
+
+## Project structure
+
+```
+.homeycompose/app.json          # SOURCE for app.json (generated file)
+drivers/pms/driver.compose.json # SOURCE for driver definition
+drivers/pms/driver.flow.compose.json # SOURCE for Flow card definitions
+widgets/recently-added/widget.compose.json # SOURCE for widget definition (auto-discovered by compose CLI >=4.3.0)
+app.json                        # GENERATED — edit .homeycompose/app.json instead
+```
+
+**Always edit the `.compose.json` / `.homeycompose/` source files**, not the generated `app.json`. The `homeycompose` plugin (listed in `.homeyplugins.json`) regenerates the output.
+
+The compose plugin auto-discovers drivers from `drivers/*/driver.compose.json`, flow cards from `drivers/*/driver.flow.compose.json`, and (compose CLI >=4.3.0) widgets from `widgets/*/widget.compose.json`. Do **not** declare widgets in `.homeycompose/app.json` — let compose discover them from the widgets directory.
+
+## Architecture
+
+All logic lives in `lib/`:
+
+| File | Role |
+|---|---|
+| `PlexApp.js` | App entrypoint; registers dashboard widget setting autocomplete |
+| `PlexDriver.js` | Pairing/repair flow via Plex OAuth PIN auth |
+| `PlexDevice.js` | Device lifecycle; polls every **60s** for recently added + server updates; handles WebSocket session events |
+| `PlexAPI.js` | Plex HTTP + WebSocket client; discoveServer connections, call `/library/recentlyAdded`, sessions, live notifications; also provides `getUpdaterStatus()` and `getServerIdentity()` |
+| `widgets/recently-added/api.js` | Widget API; endpoint returns recently added items with embedded thumbnail images proxied through Plex photo transcode |
+
+The single driver is `pms` (Plex Media Server). Driver-specific logic goes in `drivers/pms/device.js` / `drivers/pms/driver.js` — they extend the base classes.
+
+## Key dependencies
+
+- `node-fetch` v2 (uses `.json()` / `.text()`, not v3 ESM exports)
+- `faye-websocket` for WebSocket client (Plex notification stream)
+- `xml2js` for parsing `plex.tv/api/resources.xml`
+
+## Testing
+
+No test files or test scripts exist. Validate with `npm run validate` (requires Homey CLI installed globally).
+
+## Pairing flow
+
+1. App generates a UUID (clientId), calls `plex.tv/api/v2/pins` to get a PIN
+2. User visits `https://app.plex.tv/auth#...` to authorize
+3. App polls `plex.tv/api/v2/pins/{id}` every 1s (60s timeout) for auth token
+4. On success, calls `plex.tv/api/resources.xml` to list servers, tests each connection URL
+5. Device stores `token`, `clientId`, and `mostRecentlyAddedAt` in device store
+
+## Style notes
+
+- ESLint extends `athom/homey-app` with `no-shadow` off
+- Uses `this.homey.setInterval` / `setTimeout` (not global) per Homey SDK rules
+- All async error handling via `.catch(this.error)` pattern
+- No TypeScript enforcement despite `@tsconfig/node12` and `@types/homey` being present

--- a/app.json
+++ b/app.json
@@ -286,6 +286,98 @@
             "filter": "driver_id=pms"
           }
         ]
+      },
+      {
+        "id": "server_update_available",
+        "title": {
+          "en": "Server update available"
+        },
+        "hint": {
+          "en": "Fires every update check interval while a new version of Plex Media Server is available to install."
+        },
+        "tokens": [
+          {
+            "type": "string",
+            "name": "old_version",
+            "title": {
+              "en": "Old Version"
+            },
+            "example": {
+              "en": "1.40.2.8395"
+            }
+          },
+          {
+            "type": "string",
+            "name": "new_version",
+            "title": {
+              "en": "New Version"
+            },
+            "example": {
+              "en": "1.41.0.8992"
+            }
+          },
+          {
+            "type": "string",
+            "name": "added",
+            "title": {
+              "en": "New Features"
+            },
+            "example": {
+              "en": "Improved playback performance."
+            }
+          },
+          {
+            "type": "string",
+            "name": "fixed",
+            "title": {
+              "en": "Fixed Issues"
+            },
+            "example": {
+              "en": "Fixed a crash when scanning libraries."
+            }
+          },
+          {
+            "type": "string",
+            "name": "downloadURL",
+            "title": {
+              "en": "Download"
+            },
+            "example": {
+              "en": "https://plex.tv/downloads/latest/1"
+            }
+          }
+        ],
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=pms"
+          }
+        ]
+      }
+    ],
+    "conditions": [
+      {
+        "id": "server_update_available",
+        "title": {
+          "en": "Server update is available"
+        },
+        "titleFormatted": {
+          "en": "Server update is available"
+        },
+        "titleFormattedNegate": {
+          "en": "Server update is not available"
+        },
+        "hint": {
+          "en": "Check if a new version of Plex Media Server is available to install."
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=pms"
+          }
+        ]
       }
     ],
     "actions": [
@@ -397,6 +489,16 @@
           "title": {
             "en": "Server"
           }
+        },
+        {
+          "id": "scrollInterval",
+          "type": "number",
+          "label": {
+            "en": "Auto-scroll interval (seconds, 0 to disable)"
+          },
+          "value": 5,
+          "min": 0,
+          "max": 60
         }
       ],
       "api": {

--- a/drivers/pms/driver.flow.compose.json
+++ b/drivers/pms/driver.flow.compose.json
@@ -16,7 +16,7 @@
             "en": "Title"
           },
           "example": {
-            "en": "Star Trek — The search for Spock"
+            "en": "Star Trek \u2014 The search for Spock"
           }
         },
         {
@@ -217,6 +217,84 @@
           }
         }
       ]
+    },
+    {
+      "id": "server_update_available",
+      "title": {
+        "en": "Server update available"
+      },
+      "hint": {
+        "en": "Fires every update check interval while a new version of Plex Media Server is available to install."
+      },
+      "tokens": [
+        {
+          "type": "string",
+          "name": "old_version",
+          "title": {
+            "en": "Old Version"
+          },
+          "example": {
+            "en": "1.40.2.8395"
+          }
+        },
+        {
+          "type": "string",
+          "name": "new_version",
+          "title": {
+            "en": "New Version"
+          },
+          "example": {
+            "en": "1.41.0.8992"
+          }
+        },
+        {
+          "type": "string",
+          "name": "added",
+          "title": {
+            "en": "New Features"
+          },
+          "example": {
+            "en": "Improved playback performance."
+          }
+        },
+        {
+          "type": "string",
+          "name": "fixed",
+          "title": {
+            "en": "Fixed Issues"
+          },
+          "example": {
+            "en": "Fixed a crash when scanning libraries."
+          }
+        },
+        {
+          "type": "string",
+          "name": "downloadURL",
+          "title": {
+            "en": "Download"
+          },
+          "example": {
+            "en": "https://plex.tv/downloads/latest/1"
+          }
+        }
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "id": "server_update_available",
+      "title": {
+        "en": "Server update is available"
+      },
+      "titleFormatted": {
+        "en": "Server update is available"
+      },
+      "titleFormattedNegate": {
+        "en": "Server update is not available"
+      },
+      "hint": {
+        "en": "Check if a new version of Plex Media Server is available to install."
+      }
     }
   ],
   "actions": [

--- a/drivers/pms/driver.js
+++ b/drivers/pms/driver.js
@@ -5,7 +5,13 @@ const PlexDriver = require('../../lib/PlexDriver');
 module.exports = class PlexMediaServerDriver extends PlexDriver {
 
   async onInit() {
-    // Rescan
+    // Server update available condition
+    this.homey.flow.getConditionCard('server_update_available')
+      .registerRunListener(async ({ device }) => {
+        const { MediaContainer: status } = await device.api.getUpdaterStatus();
+        return Boolean(status && status.canInstall);
+      });
+
     this.homey.flow.getActionCard('rescan')
       .registerRunListener(async ({ device, library }) => {
         const { key } = library;

--- a/lib/PlexAPI.js
+++ b/lib/PlexAPI.js
@@ -323,6 +323,20 @@ module.exports = class PlexAPI extends EventEmitter {
     });
   }
 
+  async getUpdaterStatus() {
+    return this.call({
+      method: 'get',
+      path: '/updater/status',
+    });
+  }
+
+  async getServerIdentity() {
+    return this.call({
+      method: 'get',
+      path: '/identity',
+    });
+  }
+
   /*
    * WebSocket API
    */

--- a/lib/PlexDevice.js
+++ b/lib/PlexDevice.js
@@ -25,11 +25,6 @@ module.exports = class PlexDevice extends Homey.Device {
       this.removeCapability('speaker_artist').catch(this.error);
     }
 
-    // this.sessionImage = null;
-    // this.image = await this.homey.images.createImage();
-    // this.image.setUrl(null);
-    // await this.setAlbumArtImage(this.image);
-
     this.sessionStates = {
       // [sessionKey]: { state }
     };
@@ -55,12 +50,6 @@ module.exports = class PlexDevice extends Homey.Device {
         delete this.api;
         throw err;
       });
-  }
-
-  async onDeleted() {
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval);
-    }
   }
 
   async onMessage(message) {
@@ -267,6 +256,37 @@ module.exports = class PlexDevice extends Homey.Device {
       .catch(err => {
         this.error(err.message || err.toString());
       });
+
+    // Check for Server Update
+    if (this.api) {
+      Promise.all([
+        this.api.getServerIdentity(),
+        this.api.getUpdaterStatus(),
+      ])
+        .then(([{ MediaContainer: identity }, { MediaContainer: status }]) => {
+          if (!status || !status.canInstall) return;
+          const [release] = status.Release || [];
+          if (!release) return;
+          this.homey.flow.getDeviceTriggerCard('server_update_available')
+            .trigger(this, {
+              old_version: identity.version || '',
+              new_version: release.version,
+              added: release.added || '',
+              fixed: release.fixed || '',
+              downloadURL: status.downloadURL || '',
+            })
+            .catch(this.error);
+        })
+        .catch(err => {
+          this.error(`Update Check Error: ${err.message}`);
+        });
+    }
+  }
+
+  async onDeleted() {
+    if (this.pollInterval) {
+      this.homey.clearInterval(this.pollInterval);
+    }
   }
 
   async rescanLibrary({ key }) {

--- a/widgets/recently-added/api.js
+++ b/widgets/recently-added/api.js
@@ -1,18 +1,54 @@
 'use strict';
 
+const fetch = require('node-fetch');
+const PlexUtil = require('../../lib/PlexUtil');
+
 module.exports = {
   async getRecentlyAdded({ homey, query }) {
     const { serverMachineIdentifier } = query;
+
     if (!serverMachineIdentifier) {
       throw new Error('Missing serverMachineIdentifier');
     }
 
     const driver = await homey.drivers.getDriver('pms');
-    const device = driver.getDevices().find(device => device.getData().machineIdentifier === serverMachineIdentifier);
+    const device = driver.getDevices().find(
+      device => device.getData().machineIdentifier === serverMachineIdentifier,
+    );
     if (!device) {
       throw new Error('Device Not Found');
     }
 
-    return device.getLibraryRecentlyAdded();
+    const [items, apiUrl] = await Promise.all([
+      device.api.getLibraryRecentlyAdded(),
+      device.api.url,
+    ]);
+    const token = device.api.token;
+
+    const results = await Promise.all(items.map(async (item) => {
+      const title = PlexUtil.getTitle(item);
+      const thumbPath = PlexUtil.getThumb(item);
+      if (!thumbPath) {
+        return { title, thumb: null };
+      }
+
+      try {
+        const imgUrl = `${apiUrl}/photo/:/transcode?width=226&height=340&minSize=1&upscale=1&url=${encodeURIComponent(thumbPath)}&X-Plex-Token=${token}`;
+        const res = await fetch(imgUrl, { timeout: 10000 });
+        if (res.status !== 200) {
+          return { title, thumb: null };
+        }
+        const buf = await res.buffer();
+        const contentType = res.headers.get('content-type') || 'image/jpeg';
+        return {
+          title,
+          thumb: `data:${contentType};base64,${buf.toString('base64')}`,
+        };
+      } catch (err) {
+        return { title, thumb: null };
+      }
+    }));
+
+    return results;
   },
 };

--- a/widgets/recently-added/public/index.html
+++ b/widgets/recently-added/public/index.html
@@ -3,33 +3,51 @@
 <head>
   <style type="text/css">
     body {
+      margin: 0;
+      padding: 0;
       overflow: hidden;
     }
 
     #items {
-      white-space: nowrap;
-      font-size: 0;
-      overflow-x: scroll;
+      display: flex;
+      gap: var(--homey-su-4);
+      overflow-x: auto;
       overflow-y: hidden;
       padding: var(--homey-su-4);
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      -webkit-overflow-scrolling: touch;
     }
 
     .item {
-      display: inline-block;
+      flex: 0 0 auto;
       position: relative;
-      margin-right: var(--homey-su-4);
       height: 170px;
-      aspect-ratio: 0.6666666667;
+      aspect-ratio: 2/3;
       border-radius: 5px;
       overflow: hidden;
+      background-color: rgba(255, 255, 255, 0.1);
       background-position: center center;
       background-repeat: no-repeat;
       background-size: cover;
       box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
     }
 
-    .item:last-child {
-      margin-right: 0;
+    .item .title {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      padding: 4px 6px;
+      font-size: 11px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.6);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   </style>
 </head>
@@ -41,23 +59,57 @@
     function onHomeyReady(Homey) {
       const $items = document.getElementById('items');
 
-      const { server } = Homey.getSettings();
+      let autoScrollTimer = null;
+
+      function getScrollStep() {
+        const firstItem = $items.querySelector('.item');
+        if (!firstItem) return 0;
+        const style = getComputedStyle($items);
+        const gap = parseInt(style.gap) || 0;
+        return firstItem.offsetWidth + gap;
+      }
+
+      function startAutoScroll() {
+        if (autoScrollTimer) return;
+        autoScrollTimer = setInterval(() => {
+          const step = getScrollStep();
+          if (step === 0) return;
+          const maxScroll = $items.scrollWidth - $items.clientWidth;
+          const target = $items.scrollLeft + step;
+          if (target >= maxScroll) {
+            $items.scrollTo({ left: 0, behavior: 'smooth' });
+          } else {
+            $items.scrollTo({ left: target, behavior: 'smooth' });
+          }
+        }, AUTO_SCROLL_INTERVAL);
+      }
+
+      const { server, scrollInterval } = Homey.getSettings();
+      const AUTO_SCROLL_INTERVAL = parseFloat(scrollInterval) >= 0 ? parseFloat(scrollInterval) * 1000 : 5000;
 
       Homey.ready({ height: 200 });
       Homey.api('GET', `/recently-added?serverMachineIdentifier=${server.machineIdentifier}`)
         .then(items => {
           for (const item of Object.values(items)) {
-            // Check item uniqueness
-            if (document.querySelector(`.item[style*="${item.image}"]`)) {
-              continue;
-            }
+            if (!item.thumb) continue;
 
-            // Add item
-            const $item = document.createElement('div');
-            $item.classList.add('item');
-            $item.style.backgroundImage = `url(${item.image})`;
-            $items.appendChild($item);
+            const $el = document.createElement('div');
+            $el.classList.add('item');
+            $el.style.backgroundImage = `url(${item.thumb})`;
+
+            const $title = document.createElement('div');
+            $title.classList.add('title');
+            $title.textContent = item.title || '';
+            $el.appendChild($title);
+
+            $items.appendChild($el);
           }
+
+          setTimeout(() => {
+            if ($items.scrollWidth > $items.clientWidth && AUTO_SCROLL_INTERVAL > 0) {
+              startAutoScroll();
+            }
+          }, 100);
         })
         .catch(console.error);
     }

--- a/widgets/recently-added/widget.compose.json
+++ b/widgets/recently-added/widget.compose.json
@@ -9,6 +9,16 @@
       "title": {
         "en": "Server"
       }
+    },
+    {
+      "id": "scrollInterval",
+      "type": "number",
+      "label": {
+        "en": "Auto-scroll interval (seconds, 0 to disable)"
+      },
+      "value": 5,
+      "min": 0,
+      "max": 60
     }
   ],
   "api": {


### PR DESCRIPTION
## Summary

Adds a `server_update_available` flow condition card and fixes the Recently Added widget's image loading and scrolling.

### Motivation

With the addition of the Dockhand plugin and use of the linuxserver.io Plex Docker image (which automatically downloads the latest PMS version at startup), I wanted a way to check for new Plex versions via the Plex Homey plugin to run a flow like:

> **Plex: update available** AND **Date & Time: time is between 3 AM and 5 AM** THEN **Dockhand: restart container plex**; **Timeline: send notification "Plex has been updated from #old_version to #new_version"**

### Changes

**`server_update_available` trigger and condition cards** (`drivers/pms/driver.flow.compose.json`, `drivers/pms/driver.js`, `lib/PlexAPI.js`, `lib/PlexDevice.js`)
- Adds a **trigger** ("Server update available") that fires every poll interval while a new version is available, with tokens `old_version`, `new_version`, `added`, `fixed`, `downloadURL`
- Adds an **"and" condition** ("Server update is available") for use in condition-based flows
- Polls `GET /updater/status` every 60s as part of the existing poll cycle
- Adds `getUpdaterStatus()` and `getServerIdentity()` methods to `PlexAPI`

**Widget image loading and auto-scroll** (`widgets/recently-added/api.js`, `widgets/recently-added/public/index.html`, `widgets/recently-added/widget.compose.json`)
- Fixes images not loading by proxying through Plex's `/photo/:/transcode` endpoint (fetches small thumbnails at 226×340 on the backend and embeds them as base64 data URIs in a single response)
- Eliminates the per-image API call approach that hit the Homey WebSocket bridge concurrency limit (~6 requests)
- Adds configurable auto-scroll for effect (touch-scroll works in the dashboard, just not in the widget editor preview); interval can be set to 0 to disable
- Uses CSS `aspect-ratio: 2/3` instead of fixed width for responsive sizing

### Disclaimer

This was developed using Opencode's Big Pickle model. Tested locally on a Homey Pro (2023), though since no newer Plex version was available at the time, only the negative condition (no update) has been validated.